### PR TITLE
[mukoyama]tempsテーブルにextra1~3カラムを追加

### DIFF
--- a/rails/mukoyama/app/controllers/temps_controller.rb
+++ b/rails/mukoyama/app/controllers/temps_controller.rb
@@ -156,7 +156,7 @@ class TempsController < ApplicationController
 
   # GET /temps/upload
   def upload
-    fnames = [:temperature, :pressure, :humidity, :illuminance, :voltage]
+    fnames = [:temperature, :pressure, :humidity, :illuminance, :voltage, :extra1, :extra2, :extra3]
     device = Device.find_by(id: params[:id])
     if device.nil?
       render status:404, text: "Device not found for id=#{params[:id]}"

--- a/rails/mukoyama/app/views/temps/index.html.erb
+++ b/rails/mukoyama/app/views/temps/index.html.erb
@@ -14,6 +14,9 @@
           <th>湿度</th>
           <th>照度</th>
           <th>電圧</th>
+          <th>extra1</th>
+          <th>extra2</th>
+          <th>extra3</th>
           <th></th>
         </tr>
       </thead>
@@ -28,6 +31,9 @@
             <td><%= temp.humidity %></td>
             <td><%= temp.illuminance %></td>
             <td><%= temp.voltage %></td>
+            <td><%= temp.extra1 %></td>
+            <td><%= temp.extra2 %></td>
+            <td><%= temp.extra3 %></td>
             <% if temp.created_at == temp.updated_at %>
               <td><%= temp.created_at %></td>
             <% else %>
@@ -37,7 +43,7 @@
         <% end %>
         <tr class="text-muted">
           <td>:</td>
-          <td colspan="7">(<%= @temps_count %>件のレコード)</td>
+          <td colspan="10">(<%= @temps_count %>件のレコード)</td>
         </tr>
         <% @temps_oldest.each do |temp| %>
           <tr>
@@ -48,6 +54,9 @@
             <td><%= temp.humidity %></td>
             <td><%= temp.illuminance %></td>
             <td><%= temp.voltage %></td>
+            <td><%= temp.extra1 %></td>
+            <td><%= temp.extra2 %></td>
+            <td><%= temp.extra3 %></td>
             <% if temp.created_at == temp.updated_at %>
               <td><%= temp.created_at %></td>
             <% else %>

--- a/rails/mukoyama/db/migrate/20180508071856_add_extra_to_temps.rb
+++ b/rails/mukoyama/db/migrate/20180508071856_add_extra_to_temps.rb
@@ -1,0 +1,7 @@
+class AddExtraToTemps < ActiveRecord::Migration
+  def change
+    add_column :temps, :extra1, :string
+    add_column :temps, :extra2, :string
+    add_column :temps, :extra3, :string
+  end
+end

--- a/rails/mukoyama/db/schema.rb
+++ b/rails/mukoyama/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180501022115) do
+ActiveRecord::Schema.define(version: 20180508071856) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer  "device_id",    limit: 4
@@ -92,6 +92,9 @@ ActiveRecord::Schema.define(version: 20180501022115) do
     t.string   "sender",      limit: 255
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+    t.string   "extra1",      limit: 255
+    t.string   "extra2",      limit: 255
+    t.string   "extra3",      limit: 255
   end
 
   add_index "temps", ["device_id", "dt"], name: "index_temps_on_device_id_and_dt", unique: true, using: :btree


### PR DESCRIPTION
標準で用意されないデータを記録するために使用するカラムを追加し、センサー等から更新できるようにした。255文字以内ならどのような値も文字列型で格納できる。
データ一覧画面で参照可。CSVダウンロードも可能。